### PR TITLE
Use custom MediaImg component if provided

### DIFF
--- a/packages/react-tweet/src/embedded-tweet.tsx
+++ b/packages/react-tweet/src/embedded-tweet.tsx
@@ -19,7 +19,9 @@ export const EmbeddedTweet = ({ tweet, components }: Props) => (
     <TweetHeader tweet={tweet} components={components} />
     {tweet.in_reply_to_status_id_str && <TweetInReplyTo tweet={tweet} />}
     <TweetBody tweet={tweet} />
-    {tweet.mediaDetails?.length ? <TweetMedia tweet={tweet} /> : null}
+    {tweet.mediaDetails?.length ? (
+      <TweetMedia tweet={tweet} components={components} />
+    ) : null}
     <TweetInfo tweet={tweet} />
     <TweetActions tweet={tweet} />
     <TweetReplies tweet={tweet} />


### PR DESCRIPTION
The setup to use a custom component for `MediaImg` was there, but was never actually passed through to the `<TweetMedia />` component, so was not working.

This resolves that issue by providing the prop to `<TweetMedia />`