### PR TITLE
get-tweet: remove now-unnecessary `no-cache`

### DIFF
--- a/packages/react-tweet/src/api/get-tweet.ts
+++ b/packages/react-tweet/src/api/get-tweet.ts
@@ -50,8 +50,7 @@ export async function getTweet(id: string): Promise<Tweet | undefined> {
     ].join(';')
   )
 
-  // The default `cache: 'force-cache'` can return 200 when there's an error
-  const res = await fetch(url.toString(), { cache: 'no-store' })
+  const res = await fetch(url.toString())
   const isJson = res.headers.get('content-type')?.includes('application/json')
   const data = isJson ? await res.json() : undefined
 


### PR DESCRIPTION
I believe the incorrect cached status codes this was added to fix was addressed here: https://github.com/vercel/next.js/pull/47096

Closes https://github.com/vercel-labs/react-tweet/issues/66