### PR TITLE
Fix link text grammar in TweetReplies component

### DIFF
--- a/packages/react-tweet/src/tweet-replies.tsx
+++ b/packages/react-tweet/src/tweet-replies.tsx
@@ -1,18 +1,27 @@
+import { useMemo } from 'react'
 import type { Tweet } from './api/index.js'
-import { getTweetUrl, getRepliesLinkText } from './utils.js'
+import { getTweetUrl, formatNumber } from './utils.js'
 import s from './tweet-replies.module.css'
 
-export const TweetReplies = ({ tweet }: { tweet: Tweet }) => (
-  <div className={s.replies}>
-    <a
-      className={s.link}
-      href={getTweetUrl(tweet)}
-      target="_blank"
-      rel="noopener noreferrer"
-    >
-      <span className={s.text}>
-        {getRepliesLinkText(tweet.conversation_count)}
-      </span>
-    </a>
-  </div>
-)
+export const TweetReplies = ({ tweet }: { tweet: Tweet }) => {
+  const repliesLinkText = useMemo(() => {
+    if (tweet.conversation_count === 0) return 'Read more on Twitter'
+
+    return tweet.conversation_count === 1
+      ? `Read ${formatNumber(tweet.conversation_count)} reply`
+      : `Read ${formatNumber(tweet.conversation_count)} replies`
+  }, [tweet.conversation_count])
+
+  return (
+    <div className={s.replies}>
+      <a
+        className={s.link}
+        href={getTweetUrl(tweet)}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <span className={s.text}>{repliesLinkText}</span>
+      </a>
+    </div>
+  )
+}

--- a/packages/react-tweet/src/tweet-replies.tsx
+++ b/packages/react-tweet/src/tweet-replies.tsx
@@ -1,5 +1,5 @@
 import type { Tweet } from './api/index.js'
-import { getTweetUrl, formatNumber } from './utils.js'
+import { getTweetUrl, getRepliesLinkText } from './utils.js'
 import s from './tweet-replies.module.css'
 
 export const TweetReplies = ({ tweet }: { tweet: Tweet }) => (
@@ -11,9 +11,7 @@ export const TweetReplies = ({ tweet }: { tweet: Tweet }) => (
       rel="noopener noreferrer"
     >
       <span className={s.text}>
-        {tweet.conversation_count > 0
-          ? `Read ${formatNumber(tweet.conversation_count)} replies`
-          : 'Read more on Twitter'}
+        {getRepliesLinkText(tweet.conversation_count)}
       </span>
     </a>
   </div>

--- a/packages/react-tweet/src/utils.ts
+++ b/packages/react-tweet/src/utils.ts
@@ -54,3 +54,11 @@ export const formatNumber = (n: number): string => {
   if (n > 999) return `${(n / 1000).toFixed(1)}K`
   return n.toString()
 }
+
+export const getRepliesLinkText = (count: number) => {
+  if (count === 0) return 'Read more on Twitter'
+
+  return count === 1
+    ? `Read ${formatNumber(count)} reply`
+    : `Read ${formatNumber(count)} replies`
+}

--- a/packages/react-tweet/src/utils.ts
+++ b/packages/react-tweet/src/utils.ts
@@ -54,11 +54,3 @@ export const formatNumber = (n: number): string => {
   if (n > 999) return `${(n / 1000).toFixed(1)}K`
   return n.toString()
 }
-
-export const getRepliesLinkText = (count: number) => {
-  if (count === 0) return 'Read more on Twitter'
-
-  return count === 1
-    ? `Read ${formatNumber(count)} reply`
-    : `Read ${formatNumber(count)} replies`
-}


### PR DESCRIPTION
There was a grammatical error in the way that the `TweetReplies` component would output text for the replies link, where it always output the pluralized version of "replies instead of using "reply" where appropriate.

For example, it would output "Read 1 replies" when it should be "Read 1 reply".

This change builds the link text looking for each possible grammatical case:

- `0` -> `Read more on Twitter`
- `1` -> `Read 1 reply`
- `2 (or more)` -> `Read 2 replies`